### PR TITLE
chore: update rock to 4.11.22

### DIFF
--- a/metacontroller/rockcraft.yaml
+++ b/metacontroller/rockcraft.yaml
@@ -23,6 +23,8 @@ parts:
     source-tag: "v4.11.22"
     build-snaps:
       - go/1.23/stable
+      # goreleaser executable needed for `make build`
+      # See: https://github.com/metacontroller/metacontroller/blob/v4.11.22/Makefile#L22
       - goreleaser/latest/stable
     build-environment:
       - CGO_ENABLED: 0
@@ -41,4 +43,3 @@ parts:
       dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
       > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
 
-    

--- a/metacontroller/rockcraft.yaml
+++ b/metacontroller/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Based on https://github.com/metacontroller/metacontroller/blob/v3.0.0/Dockerfile
+# Based on https://github.com/metacontroller/metacontroller/blob/v4.0.0/Dockerfile
 name: metacontroller
 summary: Metacontroller in a rock.
 description: "Metacontroller  is an add-on for Kubernetes that makes it easy to write and deploy custom controllers in the form of simple scripts."

--- a/metacontroller/rockcraft.yaml
+++ b/metacontroller/rockcraft.yaml
@@ -2,7 +2,7 @@
 name: metacontroller
 summary: Metacontroller in a rock.
 description: "Metacontroller  is an add-on for Kubernetes that makes it easy to write and deploy custom controllers in the form of simple scripts."
-version: "3.0.0"
+version: "4.0.0"
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
@@ -20,7 +20,7 @@ parts:
     plugin: go
     source: https://github.com/metacontroller/metacontroller
     source-type: git
-    source-tag: "v3.0.0"
+    source-tag: "v4.0.0"
     build-snaps:
       - go/1.18/stable
     build-environment:

--- a/metacontroller/rockcraft.yaml
+++ b/metacontroller/rockcraft.yaml
@@ -1,15 +1,15 @@
-# Based on https://github.com/metacontroller/metacontroller/blob/v4.0.0/Dockerfile
+# Based on https://github.com/metacontroller/metacontroller/blob/v4.11.22/Dockerfile
 name: metacontroller
 summary: Metacontroller in a rock.
 description: "Metacontroller  is an add-on for Kubernetes that makes it easy to write and deploy custom controllers in the form of simple scripts."
-version: "4.0.0"
+version: "4.11.22"
 license: Apache-2.0
 base: ubuntu@22.04
-run-user: _daemon_
 services:
   metacontroller:
     command: metacontroller
     working-dir: /usr/bin
+    user: nonroot
     override: replace
     startup: enabled
 platforms:
@@ -20,17 +20,18 @@ parts:
     plugin: go
     source: https://github.com/metacontroller/metacontroller
     source-type: git
-    source-tag: "v4.0.0"
+    source-tag: "v4.11.22"
     build-snaps:
-      - go/1.18/stable
+      - go/1.23/stable
+      - goreleaser/latest/stable
     build-environment:
       - CGO_ENABLED: 0
     stage-packages:
       - ca-certificates
     override-build: |
-      make install
+      make build
       mkdir -p ${CRAFT_PART_INSTALL}/usr/bin
-      install -D ${CRAFT_PART_INSTALL}/bin/metacontroller ${CRAFT_PART_INSTALL}/usr/bin
+      install -D metacontroller ${CRAFT_PART_INSTALL}/usr/bin
 
   security-team-requirement:
     plugin: nil
@@ -39,3 +40,13 @@ parts:
       (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
       dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
       > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  # not-root user for this rock should be "nonroot"
+  non-root-user:
+    plugin: nil
+    after: [metacontroller]
+    overlay-script: |
+      # Create a user in the $CRAFT_OVERLAY chroot
+      groupadd -R $CRAFT_OVERLAY -g 65532 -r nonroot
+      useradd -R $CRAFT_OVERLAY -M -s /bin/bash -u 65532 -g nonroot -r nonroot
+    

--- a/metacontroller/rockcraft.yaml
+++ b/metacontroller/rockcraft.yaml
@@ -5,11 +5,11 @@ description: "Metacontroller  is an add-on for Kubernetes that makes it easy to 
 version: "4.11.22"
 license: Apache-2.0
 base: ubuntu@22.04
+run-user: _daemon_
 services:
   metacontroller:
     command: metacontroller
     working-dir: /usr/bin
-    user: nonroot
     override: replace
     startup: enabled
 platforms:
@@ -41,12 +41,4 @@ parts:
       dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
       > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
 
-  # not-root user for this rock should be "nonroot"
-  non-root-user:
-    plugin: nil
-    after: [metacontroller]
-    overlay-script: |
-      # Create a user in the $CRAFT_OVERLAY chroot
-      groupadd -R $CRAFT_OVERLAY -g 65532 -r nonroot
-      useradd -R $CRAFT_OVERLAY -M -s /bin/bash -u 65532 -g nonroot -r nonroot
     

--- a/metacontroller/tox.ini
+++ b/metacontroller/tox.ini
@@ -24,7 +24,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-    skopeo
+	rockcraft
     yq
 commands =
     # pack rock and export to docker
@@ -34,7 +34,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *

--- a/metacontroller/tox.ini
+++ b/metacontroller/tox.ini
@@ -24,7 +24,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-	rockcraft
+    rockcraft
     yq
 commands =
     # pack rock and export to docker


### PR DESCRIPTION
This PR updates the `metacontroller` rock to version `4.11.22`. This matches the updated version used in `kubeflow/manifests`, updated in [this commit](https://github.com/kubeflow/manifests/commit/27eb1a50e0d3c41567ca6d6b147a063273713c4d).

Some small notes:
- I got the Go version by finding what version is included the version of `alpine` that upstream uses
- We need the `goreleaser` snap (we install the latest because the Github action in upstream also uses the latest version)
- We now use a specific user called `nonroot`. For this to work we have to run Pebble as `root`, as we do for example with the [kfam rock](https://github.com/canonical/kubeflow-rocks/blob/main/kfam/rockcraft.yaml)

I also updated the `tox.ini` to use `rockcraft.skopeo` since we already use it for packing

## How to ensure that it is working
First pull and run the upstream image:
```
docker pull ghcr.io/metacontroller/metacontroller:v4.11.22
docker run --rm -it ghcr.io/metacontroller/metacontroller:v4.11.22
```
You should see output similar to:
```
{"level":"info","ts":"2025-02-28T11:16:06Z","msg":"Configuration information","discovery-interval":30,"cache-flush-interval":1800,"metrics-address":":9999","client-go-qps":5,"client-go-burst":10,"workers":5,"events-qps":0.0033333333333333335,"events-burst":25,"pprofAddr":"0","leader-election":false,"leader-election-resource-lock":"leases","leader-election-namespace":"","leader-election-id":"metacontroller","health-probe-bind-address":":8081","target-label-selector":"","version":"4.11.22"}
{"level":"error","ts":"2025-02-28T11:16:06Z","logger":"controller-runtime.client.config","msg":"unable to load in-cluster config","error":"unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined","stacktrace":"sigs.k8s.io/controller-runtime/pkg/client/config.loadConfig.func1\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.3/pkg/client/config/config.go:133\nsigs.k8s.io/controller-runtime/pkg/client/config.loadConfig\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.3/pkg/client/config/config.go:155\nsigs.k8s.io/controller-runtime/pkg/client/config.GetConfigWithContext\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.3/pkg/client/config/config.go:97\nsigs.k8s.io/controller-runtime/pkg/client/config.GetConfig\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.3/pkg/client/config/config.go:77\nmain.main\n\t/home/runner/work/metacontroller/metacontroller/pkg/cmd/metacontroller/main.go:89\nruntime.main\n\t/opt/hostedtoolcache/go/1.23.3/x64/src/runtime/proc.go:272"}
{"level":"error","ts":"2025-02-28T11:16:06Z","msg":"Terminating","error":"invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable","errorCauses":[{"error":"no configuration has been provided, try setting KUBERNETES_MASTER environment variable"}],"stacktrace":"main.main\n\t/home/runner/work/metacontroller/metacontroller/pkg/cmd/metacontroller/main.go:91\nruntime.main\n\t/opt/hostedtoolcache/go/1.23.3/x64/src/runtime/proc.go:272"}
```

Then pack, export to docker, and run the rock:
```
rockcraft pack
tox -e export-to-docker
docker run --rm -it <image-id>
```

Run bash in this container from a different terminal window, and run pebble logs:
```
docker ps
docker exec -it <containerid> bash
pebble logs
```
You should see the same output :)